### PR TITLE
Read/Write Platform Volume Mount

### DIFF
--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -16,7 +16,7 @@ The `pack` CLI should expand its volume mounting functionality to allow arbitrar
 # Motivation
 [motivation]: #motivation
 
-Currently, every part of the filesystem available during `detect` and every part of the filesystem other than layers during `build` are read-only.  This satisifies most use-cases, but specifically does not support the possibility of multiple builds sharing a communal filesystem location.  While this would likely to be a disaster in many situations, especially in production environments, being able to share a filesystem between a development laptop and a build is _very_ useful.  For example, the single longest bit of building a Java application from source is the initial population of a Maven or Gradle cache.  Hundreds and perhaps thousands of artifacts are downlaoded to do the very first build and subsequently never need to be downloaded again.  Caching these artifacts in a `cache = true` layer helps, but doesn't solve the first build speed problem and results in a pretty poor demo experience.  If a user could mount their `~/.m2` or `~/.gradle` folders into the build container, accepting the overall risk of such a choice, the experience would be vastly superior.
+Currently, every part of the filesystem available during `detect` and every part of the filesystem other than layers during `build` are read-only.  This satisfies most use-cases, but specifically does not support the possibility of multiple builds sharing a communal filesystem location.  While this would likely to be a disaster in many situations, especially in production environments, being able to share a filesystem between a development laptop and a build is _very_ useful.  For example, the single longest bit of building a Java application from source is the initial population of a Maven or Gradle cache.  Hundreds and perhaps thousands of artifacts are downloaded to do the very first build and subsequently never need to be downloaded again.  Caching these artifacts in a `cache = true` layer helps, but doesn't solve the first build speed problem and results in a pretty poor demo experience.  If a user could mount their `~/.m2` or `~/.gradle` folders into the build container, accepting the overall risk of such a choice, the experience would be vastly superior.
 
 This benefit is generally useful and extends beyond build caches to nearly every aspect of buildpack usage including development of both buildpacks and the lifecycle.
 
@@ -35,7 +35,7 @@ The technical details are opaque and implementation dependent as this is a chang
 
 * There is an amazing amount of danger in using a shared filesystem in distributed systems.
 * Performance problems accessing shared filesystems in distributed systems.
-* Performance problems accessing a local filessystem from within the MacOS Docker Daemon.
+* Performance problems accessing a local filesystem from within the MacOS Docker Daemon.
 
 # Alternatives
 [alternatives]: #alternatives
@@ -52,7 +52,7 @@ The technical details are opaque and implementation dependent as this is a chang
 # Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
-* Should certain CNB-reserved folders be mountable?  I believe that preventing mounts at their lcoations restricts the upside to this feature, without adding a significant amount of safety.  The overall feature is quite dangerous and special-casing two folders isn't going to change that signficantly.
+* Should certain CNB-reserved folders be mountable?  I believe that preventing mounts at their locations restricts the upside to this feature, without adding a significant amount of safety.  The overall feature is quite dangerous and special-casing two folders isn't going to change that significantly.
 
 # Spec. Changes (OPTIONAL)
 [spec-changes]: #spec-changes

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -36,6 +36,7 @@ The technical details are opaque and implementation dependent as this is a chang
 * There is an amazing amount of danger in using a shared filesystem in distributed systems.
 * Performance problems accessing shared filesystems in distributed systems.
 * Performance problems accessing a local filesystem from within the MacOS Docker Daemon.
+* There are signficant risks around file ownership on Linux hosts
 
 # Alternatives
 [alternatives]: #alternatives
@@ -53,6 +54,7 @@ The technical details are opaque and implementation dependent as this is a chang
 [unresolved-questions]: #unresolved-questions
 
 * Should certain CNB-reserved folders be mountable?  I believe that preventing mounts at their locations restricts the upside to this feature, without adding a significant amount of safety.  The overall feature is quite dangerous and special-casing two folders isn't going to change that significantly.
+* Should this be included behind experimental support of the `pack` CLI?
 
 # Spec. Changes (OPTIONAL)
 [spec-changes]: #spec-changes

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -25,6 +25,13 @@ This benefit is generally useful and extends beyond build caches to nearly every
 
 Currently, the `pack` CLI has a `--volume` flag that allows users to expose a local filesystem location as a read-only volume mount into the `/platform` directory.  This change should generalize that flag and allow it to mount a local filesystem location as a read-write volume mount into any location within the build container.  If a user chooses to mount at any specification-reserved files system location (e.g. `/cnb` or `/layers`), a warning should be displayed.
 
+`--volume` will allow `mode` as an optional third colon separated parameter.
+
+Format: `--volume=<src>:<target>[:mode]`
+
+Mode values:
+* `ro` - Read-only (default)
+* `rw` - Read/Write
 # How it Works
 [how-it-works]: #how-it-works
 
@@ -36,7 +43,8 @@ The technical details are opaque and implementation dependent as this is a chang
 * There is an amazing amount of danger in using a shared filesystem in distributed systems.
 * Performance problems accessing shared filesystems in distributed systems.
 * Performance problems accessing a local filesystem from within the MacOS Docker Daemon.
-* There are signficant risks around file ownership on Linux hosts
+* There are significant risks around file ownership on Linux hosts
+* There would be a small transition period of incompatibility for users that already use `--volume` for mounting platform directories.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -50,7 +50,7 @@ A folder named `/platform/unsafe` should be reserved by specification.  Within t
 # Prior Art
 [prior-art]: #prior-art
 
-No relavant priort art.
+Currently, arbitrary read-only volumes can be mounted under `/platform`.  The outcome of this RFC would be similar with looser permissions and more risk.
 
 # Unresolved Questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -21,18 +21,12 @@ Currently, every part of the filesystem available during `detect` and every part
 # What it is
 [what-it-is]: #what-it-is
 
-This provides a high level overview of the feature.
-
-- Define any new terminology.
-- Define the target persona: buildpack author, buildpack user, platform operator, platform implementor, and/or project contributor.
-- Explaining the feature largely in terms of examples.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing users and new users.
+A folder named `/platform/unsafe` should be reserved by specification.  Within that folder, an arbitrary collection of directories could be mounted (e.g. `/platform/unsafe/{gradle,maven}`).  Each of the mounts at those specified children would be ready/write instead of read only as all other mounts are configured.  Buildpacks have complete access during both `detect` and `build` and no other enforcment is required.
 
 # How it Works
 [how-it-works]: #how-it-works
 
-A folder named `/platform/unsafe` should be reserved by specification.  Within that folder, an arbitrary collection of directories could be mounted (e.g. `/platform/unsafe/{gradle,maven}`).  Each of the mounts at those specified children would be ready/write instead of read only as all other mounts are configured.  Buildpacks have complete access during both `detect` and `build` and no other enforcment is required.
+The technical details are platform implementation dependent as this is a change to the specification.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -1,0 +1,64 @@
+# Meta
+[meta]: #meta
+- Name: Read/Write Platform Volume Mount
+- Start Date: 2020-06-02
+- Author(s): nebhale
+- RFC Pull Request: (leave blank)
+- CNB Pull Request: (leave blank)
+- CNB Issue: (leave blank)
+- Supersedes: (put "N/A" unless this replaces an existing RFC, then link to that RFC)
+
+# Summary
+[summary]: #summary
+
+Buildpacks should have access to a read/write file system location provided by the platform.
+
+# Motivation
+[motivation]: #motivation
+
+Currently, every part of the filesystem available during `detect` and every part of the filesystem other than layers during `build` are read-only.  This satisifies most use-cases, but specifically does not support the possibility of multiple builds sharing a communal filesystem location.  While this would likely to be a disaster in many situations, especially in production environments, being able to share a filesystem between a development laptop and a build is _very_ useful.  For example, the single longest bit of building a Java application from source is the initial population of a Maven or Gradle cache.  Hundreds and perhaps thousands of artifacts are downlaoded to do the very first build and subsequently never need to be downloaded again.  Caching these artifacts in a `cache = true` layer helps, but doesn't solve the first build speed problem and results in a pretty poor demo experience.  If a user could mount their `~/.m2` or `~/.gradle` folders into a safe location within the build container, accepting the overall risk of such a choice, the experience would be vastly superior.
+
+# What it is
+[what-it-is]: #what-it-is
+
+This provides a high level overview of the feature.
+
+- Define any new terminology.
+- Define the target persona: buildpack author, buildpack user, platform operator, platform implementor, and/or project contributor.
+- Explaining the feature largely in terms of examples.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing users and new users.
+
+# How it Works
+[how-it-works]: #how-it-works
+
+A folder named `/platform/unsafe` should be reserved by specification.  Within that folder, an arbitrary collection of directories could be mounted (e.g. `/platform/unsafe/{gradle,maven}`).  Each of the mounts at those specified children would be ready/write instead of read only as all other mounts are configured.  Buildpacks have complete access during both `detect` and `build` and no other enforcment is required.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* There is an amazing amount of danger in using a shared filessystem in distributed systems.
+* Performance problems accessing shared filesystems in distributed systems.
+* Performance problems accessing a local filessystem from within the MacOS Docker Daemon.
+
+# Alternatives
+[alternatives]: #alternatives
+
+* There don't appear to be any viable strategies for exposing a local filesystem to the build container.
+* Not doing this leaves things with the status quo which isn't horrible.
+
+# Prior Art
+[prior-art]: #prior-art
+
+No relavant priort art.
+
+# Unresolved Questions
+[unresolved-questions]: #unresolved-questions
+
+* Should the folder actually be called `/platform/danger-zone`?
+
+# Spec. Changes (OPTIONAL)
+[spec-changes]: #spec-changes
+
+* The buildpack specification will need to describe a reserved folder in `/platform` where read/write filesystems can be mounted.
+* The platform specification will need to describe how to communicate to the `lifecycle` what folders to mount.

--- a/text/0000-danger-zone.md
+++ b/text/0000-danger-zone.md
@@ -23,7 +23,7 @@ This benefit is generally useful and extends beyond build caches to nearly every
 # What it is
 [what-it-is]: #what-it-is
 
-Currently, the `pack` CLI has a `--volume` flag that allows users to expose a local filesystem location as a read-only volume mount into the `/platform` directory.  This change should generalize that flag and allow it to mount a local filesystem location as a read-write volume mount into any location within the build container.
+Currently, the `pack` CLI has a `--volume` flag that allows users to expose a local filesystem location as a read-only volume mount into the `/platform` directory.  This change should generalize that flag and allow it to mount a local filesystem location as a read-write volume mount into any location within the build container.  If a user chooses to mount at any specification-reserved files system location (e.g. `/cnb` or `/layers`), a warning should be displayed.
 
 # How it Works
 [how-it-works]: #how-it-works


### PR DESCRIPTION
This change proposes a well-known location in /platform for mounting read/write filesystems.
