### PR TITLE
discrepancy in result json

### DIFF
--- a/text/0068-buildpack-registry-search-api.md
+++ b/text/0068-buildpack-registry-search-api.md
@@ -135,10 +135,10 @@ All the endpoints defined below will be version via a `vN` prefix to the base UR
     },
     "versions": {
       "1.4.1": {
-        "link": "https://registry.buildpacks.io/buildpacks/api/v1/projectriff/command-function/1.4.1"
+        "link": "https://registry.buildpacks.io/api/v1/buildpacks/projectriff/command-function/1.4.1"
       },
       "1.3.9": {
-        "link": "https://registry.buildpacks.io/buildpacks/api/v1/projectriff/command-function/1.3.9"
+        "link": "https://registry.buildpacks.io/api/v1/buildpacks/projectriff/command-function/1.3.9"
       }
     }
   }


### PR DESCRIPTION
As mentioned in [Update schema to match API proposed in RFC](https://github.com/buildpacks/registry-api/issues/3), the schema seems correct but, there is some discrepancy in output JSON. The pull request fixes that.

Schema:
![image](https://user-images.githubusercontent.com/50852113/115123626-9092bd00-9f83-11eb-8abe-12699ea74a4d.png)

Discrepancy: 
![image](https://user-images.githubusercontent.com/50852113/115123487-e1ee7c80-9f82-11eb-9ba9-db86eec4a80d.png)






Signed-off-by: Aswin Timalsina <aswin.timalsina1@gmail.com>