### PR TITLE
Add Migration section to template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -44,6 +44,11 @@ This is the technical portion of the RFC, where you explain the design in suffic
 
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
+# Migration
+[migration]: #migration
+
+This section should document breaks to public API and breaks in compatibility due to this RFC's proposed changes. In addition, it should document the proposed steps that one would need to take to work through these changes. Care should be give to include all applicable personas, such as platform developers, buildpack developers, buildpack users and consumers of buildpack images.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 


### PR DESCRIPTION
Initially [proposed here](https://buildpacks.slack.com/archives/C94UJCNV6/p1639075530135600).

This PR adds a Migration section to the RFC template. The purpose of this section is to ensure consideration is given to how an RFC might break existing APIs and workflows so that a discussion can be had in advance of an RFC being approved.

As we get more and more users, this seems like an appropriate step to take to show that stability and continuity are important considerations as we evolve buildpacks.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>