### PR TITLE
Fix delimiter in RFC 109

### DIFF
--- a/text/0109-build-config.md
+++ b/text/0109-build-config.md
@@ -58,7 +58,7 @@ Final value: `FOO=test`
 
 
 Buildpack value: `FOO=test`
-Build config: `FOO.append=another-value, FOO.delim="`
+Build config: `FOO.append=another-value, FOO.delim=:`
 Final value: `FOO=test:another-value`
 
 Buildpack value: `FOO=test`


### PR DESCRIPTION
The delimiter used in an example is a colon
not a double quote character.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>