### PR TITLE
Rename Build Config env variable

### DIFF
--- a/text/0109-build-config.md
+++ b/text/0109-build-config.md
@@ -118,5 +118,5 @@ N/A
 
 Addition of the definition of the above directory in the Platform specification i.e. - 
 
-- `CNB_CONFIG_DIR`
+- `CNB_BUILD_CONFIG_DIR`
 - `/cnb/config/env.build`


### PR DESCRIPTION
Use the name `CNB_BUILD_CONFIG_DIR` as provided in the sample implementation.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>