### PR TITLE
Fix example process definition in RFC 0093

### DIFF
--- a/text/0093-remove-shell-processes.md
+++ b/text/0093-remove-shell-processes.md
@@ -108,7 +108,7 @@ Using the new API this process could look like:
 ```
 [[processes]]
 type = "bash"
-command = ["-c", "dotnet", "my-app.dll", "--urls", "http://0.0.0.0:${PORT:-8080}"]
+command = ["bash", "-c", "dotnet", "my-app.dll", "--urls", "http://0.0.0.0:${PORT:-8080}"]
 default = true
 ```
 Things to note:


### PR DESCRIPTION
RFC 0093 contains a number of examples of how to migrate a buildpack away from `direct=false` mode.

One of these examples was missing the "bash" command prior to the "-c" argument.