### PR TITLE
Fix manually merged RFCs

### DIFF
--- a/text/0126-creator-skip-sbom.md
+++ b/text/0126-creator-skip-sbom.md
@@ -3,7 +3,7 @@
 - Name: Enable CNB_SKIP_SBOM IN /cnb/lifecycle/creator
 - Start Date: (fill in today's date: 2023-10-17)
 - Author(s): kritkasahni-google
-- Status: Draft
+- Status: Approved
 - RFC Pull Request: 
 - CNB Pull Request: 
 - CNB Issue: 

--- a/text/0127-extension-layer.md
+++ b/text/0127-extension-layer.md
@@ -3,7 +3,7 @@
 - Name: Add extension layer to exchange data
 - Start Date: 2023-10-09
 - Author(s): [c0d1ngm0nk3y](https://github.com/c0d1ngm0nk3y), [pbusko](https://github.com/pbusko)
-- Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
+- Status: Approved
 - RFC Pull Request:
 - CNB Pull Request:
 - CNB Issue:


### PR DESCRIPTION
Something is wrong with `merge-rfc.sh`, as this has happened before (see https://github.com/buildpacks/rfcs/commit/458442d6e3ca136280d6eecfbc1ed4f281f3c9a2). Fixing the latest two for now...